### PR TITLE
fix msg.util.set.color for current fish

### DIFF
--- a/msg.util.set.color.fish
+++ b/msg.util.set.color.fish
@@ -1,6 +1,6 @@
 # Set style, fg/bg colors and reset. Modifies its parent scope of `msg`.
 # @params [<fg>] [<bg>] [<style>]
-function --no-scope-shadowing msg.util.set.color
+function msg.util.set.color --no-scope-shadowing
   if [ (count $argv) -gt 0 ]
     set fg $argv[1]
   end


### PR DESCRIPTION
options must come after the function name, else we get:

    Illegal function name '--no-scope-shadowing'

(tested with fish version 2.7.1)